### PR TITLE
Make example consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module.exports = {
   },
   plugins: [
     // ...
-    new NukecssPlugin()
+    new NukeCssPlugin()
   ],
 }
 ````


### PR DESCRIPTION
Fix: In the usage example, the plugin was imported as NukeCssPlugin but used as NukecssPlugin. Therefore the example didn't work.